### PR TITLE
Switch to fst crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ crate-type = ["cdylib", "rlib"]
 debug = true
 
 [build-dependencies]
-fst = { version = "0.3", default-features = false }
+fst = { version = "0.3.4", default-features = false }
 xz2 = "0.1"
 
 [dependencies]
-fst = { version = "0.3", default-features = false }
+fst = { version = "0.3.4", default-features = false }
 lazy_static = "1.3"
 wasm-bindgen = "0.2.48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ crate-type = ["cdylib", "rlib"]
 debug = true
 
 [build-dependencies]
+fst = { version = "0.3", default-features = false }
 xz2 = "0.1"
-phf_codegen = { git = "https://github.com/sfackler/rust-phf" }
 
 [dependencies]
-phf = { git = "https://github.com/sfackler/rust-phf" }
+fst = { version = "0.3", default-features = false }
+lazy_static = "1.3"
 wasm-bindgen = "0.2.48"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
+use fst::Set;
+use lazy_static::lazy_static;
 use wasm_bindgen::prelude::*;
 
-include!(concat!(env!("OUT_DIR"), "/password_hash.rs"));
+const FST: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/password_hash.fst"));
+
+lazy_static! {
+    static ref PASSWORDS: Set = Set::from_bytes(FST.to_owned()).unwrap();
+}
 
 #[wasm_bindgen]
 pub fn is_compromised(test_password: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
-use fst::Set;
+use fst::raw::Fst;
 use lazy_static::lazy_static;
 use wasm_bindgen::prelude::*;
 
 const FST: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/password_hash.fst"));
 
 lazy_static! {
-    static ref PASSWORDS: Set = Set::from_bytes(FST.to_owned()).unwrap();
+    static ref PASSWORDS: Fst = Fst::from_static_slice(FST).unwrap();
 }
 
 #[wasm_bindgen]
 pub fn is_compromised(test_password: &str) -> bool {
-    PASSWORDS.contains(test_password)
+    PASSWORDS.contains_key(test_password)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
-use fst::raw::Fst;
+use fst::Set;
 use lazy_static::lazy_static;
 use wasm_bindgen::prelude::*;
 
 const FST: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/password_hash.fst"));
 
 lazy_static! {
-    static ref PASSWORDS: Fst = Fst::from_static_slice(FST).unwrap();
+    static ref PASSWORDS: Set = Set::from_static_slice(FST).unwrap();
 }
 
 #[wasm_bindgen]
 pub fn is_compromised(test_password: &str) -> bool {
-    PASSWORDS.contains_key(test_password)
+    PASSWORDS.contains(test_password)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This compiles 12x faster on my machine (dependencies included) and produces a wasm file that is 3.9x smaller at 4.3 MB.